### PR TITLE
Install unvulnerable git

### DIFF
--- a/1.10.3-dep/Dockerfile
+++ b/1.10.3-dep/Dockerfile
@@ -1,4 +1,20 @@
 FROM golang:1.10.3
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.10.3-dep/Dockerfile
+++ b/1.10.3-dep/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.10.3-glide/Dockerfile
+++ b/1.10.3-glide/Dockerfile
@@ -1,4 +1,20 @@
 FROM golang:1.10.3
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN curl https://glide.sh/get | sh
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.10.3-glide/Dockerfile
+++ b/1.10.3-glide/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.11-dep/Dockerfile
+++ b/1.11-dep/Dockerfile
@@ -1,4 +1,20 @@
 FROM golang:1.11
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.11-dep/Dockerfile
+++ b/1.11-dep/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.11-glide/Dockerfile
+++ b/1.11-glide/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.11-glide/Dockerfile
+++ b/1.11-glide/Dockerfile
@@ -1,4 +1,20 @@
 FROM golang:1.11
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN curl https://glide.sh/get | sh
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.11.1/Dockerfile
+++ b/1.11.1/Dockerfile
@@ -1,3 +1,19 @@
 FROM golang:1.11.1
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.11.1/Dockerfile
+++ b/1.11.1/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.11.4-dep/Dockerfile
+++ b/1.11.4-dep/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.11.4-dep/Dockerfile
+++ b/1.11.4-dep/Dockerfile
@@ -1,4 +1,20 @@
 FROM golang:1.11.4
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.11.4-glide/Dockerfile
+++ b/1.11.4-glide/Dockerfile
@@ -1,4 +1,20 @@
 FROM golang:1.11.4
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN curl https://glide.sh/get | sh
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.11.4-glide/Dockerfile
+++ b/1.11.4-glide/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.11.4/Dockerfile
+++ b/1.11.4/Dockerfile
@@ -1,3 +1,19 @@
 FROM golang:1.11.4
+
+ENV GIT_VERSION=v2.26.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.11.4/Dockerfile
+++ b/1.11.4/Dockerfile
@@ -6,7 +6,7 @@ ENV GIT_VERSION=v2.26.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.12-dep/Dockerfile
+++ b/1.12-dep/Dockerfile
@@ -1,5 +1,22 @@
 FROM golang:1.12
+
+ENV GIT_VERSION=v2.26.1
+ENV GOLANGCI_LINT_VERSION=v1.25.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN go get -u github.com/golang/dep/cmd/dep
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.12-dep/Dockerfile
+++ b/1.12-dep/Dockerfile
@@ -7,7 +7,7 @@ ENV GOLANGCI_LINT_VERSION=v1.25.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.12-glide/Dockerfile
+++ b/1.12-glide/Dockerfile
@@ -1,5 +1,22 @@
 FROM golang:1.12
+
+ENV GIT_VERSION=v2.26.1
+ENV GOLANGCI_LINT_VERSION=v1.25.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
 RUN curl https://glide.sh/get | sh
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.12-glide/Dockerfile
+++ b/1.12-glide/Dockerfile
@@ -7,7 +7,7 @@ ENV GOLANGCI_LINT_VERSION=v1.25.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -1,4 +1,21 @@
 FROM golang:1.12
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
+ENV GIT_VERSION=v2.26.1
+ENV GOLANGCI_LINT_VERSION=v1.25.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
+RUN GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -7,7 +7,7 @@ ENV GOLANGCI_LINT_VERSION=v1.25.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \

--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -1,2 +1,19 @@
 FROM golang:1.13
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
+ENV GIT_VERSION=v2.26.1
+ENV GOLANGCI_LINT_VERSION=v1.25.1
+
+# Install not vulnerable git
+# SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
+#      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
+RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
+  && apt update --allow-releaseinfo-change \
+  && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
+  && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
+  && unzip git.zip \
+  && cd git-* \
+  && make prefix=/usr/local all \
+  && make prefix=/usr/local install \
+  && rm -rf git-*
+
+RUN GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}

--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -7,7 +7,7 @@ ENV GOLANGCI_LINT_VERSION=v1.25.1
 # SEE: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10
 #      https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
 RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
-  && apt update --allow-releaseinfo-change \
+  && apt update \
   && apt install -y make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip \
   && wget https://github.com/git/git/archive/${GIT_VERSION}.zip -O git.zip \
   && unzip git.zip \


### PR DESCRIPTION
## Overview

In Git 2.26.0 and below, there is a vulnerability that allows a Git clone of a crafted repository to steal the user's credentials (for example, the credentials used to clone GitHub.com).

The go get command uses git command internally, and I will update the git version.

## Reference

- [malicious URLs may cause Git to present stored credentials to the wrong server · Advisory · git/git](https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q)