### PR TITLE
Fix golangci-lint install commands

### DIFF
--- a/1.12-dep/Dockerfile
+++ b/1.12-dep/Dockerfile
@@ -17,6 +17,10 @@ RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
   && rm -rf git-*
 
 RUN go get -u github.com/golang/dep/cmd/dep
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+RUN wget https://github.com/golangci/golangci-lint/archive/${GOLANGCI_LINT_VERSION}.zip -O golangci-lint.zip \
+ && unzip golangci-lint.zip \
+ && cd golangci-lint-* \
+ && make build \
+ && cp ./golangci-lint /go/bin/.
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.12-glide/Dockerfile
+++ b/1.12-glide/Dockerfile
@@ -22,6 +22,5 @@ RUN wget https://github.com/golangci/golangci-lint/archive/${GOLANGCI_LINT_VERSI
  && cd golangci-lint-* \
  && make build \
  && cp ./golangci-lint /go/bin/. 
-
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/1.12-glide/Dockerfile
+++ b/1.12-glide/Dockerfile
@@ -17,6 +17,11 @@ RUN sed -e 's/deb /deb \[trusted=yes\] /g' -i /etc/apt/sources.list \
   && rm -rf git-*
 
 RUN curl https://glide.sh/get | sh
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+RUN wget https://github.com/golangci/golangci-lint/archive/${GOLANGCI_LINT_VERSION}.zip -O golangci-lint.zip \
+ && unzip golangci-lint.zip \
+ && cd golangci-lint-* \
+ && make build \
+ && cp ./golangci-lint /go/bin/. 
+
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install


### PR DESCRIPTION
Use `wget` insted of `go get`.